### PR TITLE
feat: Improve divider styling in PDASharingTab

### DIFF
--- a/src/app/(light)/dashboard/user/asset/[id]/components/tabs/pda-sharing-tab.tsx
+++ b/src/app/(light)/dashboard/user/asset/[id]/components/tabs/pda-sharing-tab.tsx
@@ -10,7 +10,15 @@ import { IndividualDetailRow } from './components';
 export default function PDASharingTab({ pda }: { pda: PrivateDataAsset }) {
   return (
     <IndividualDetailRow>
-      <Stack divider={<Divider />}>
+      <Stack
+        divider={
+          <Divider
+            sx={{
+              mx: { xs: 0, lg: -4 },
+            }}
+          />
+        }
+      >
         {pda.proofs.map((proof) => {
           const verifier = getIdentity({
             user: proof.verifier!,


### PR DESCRIPTION
The code changes modify the styling of the divider in the PDASharingTab component. The divider now has a margin on the x-axis to adjust its position. This change improves the visual appearance of the component.

Recent repository commits suggest using the "feat" prefix for feature-related changes.